### PR TITLE
Added CORE-V hardware loop support

### DIFF
--- a/bfd/ChangeLog.COREV
+++ b/bfd/ChangeLog.COREV
@@ -1,0 +1,3 @@
+2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* bfd-in2.h: Added CORE-V hardware loop specific relocations.

--- a/bfd/bfd-in2.h
+++ b/bfd/bfd-in2.h
@@ -4407,6 +4407,10 @@ number for the SBIC, SBIS, SBI and CBI instructions  */
   BFD_RELOC_RISCV_SET32,
   BFD_RELOC_RISCV_32_PCREL,
 
+/* Riscv, CORE-V Specific */
+  BFD_RELOC_RISCV_REL12,
+  BFD_RELOC_RISCV_RELU5,
+
 /* Renesas RL78 Relocations.  */
   BFD_RELOC_RL78_NEG8,
   BFD_RELOC_RL78_NEG16,

--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,0 +1,4 @@
+2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c: Added CORE-V harware loop support.
+	* config/tc-riscv.h: Likewise.

--- a/gas/config/tc-riscv.h
+++ b/gas/config/tc-riscv.h
@@ -117,8 +117,9 @@ extern int tc_riscv_regname_to_dw2regnum (char *);
 #define elf_tc_final_processing riscv_elf_final_processing
 extern void riscv_elf_final_processing (void);
 
+/* TODO: DO WE NEED THIS */
 extern void pulp_md_end (void);
-#define md_end() pulp_md_end()
+#define pulp_md_end()
 
 /* Adjust debug_line after relaxation.  */
 #define DWARF2_USE_FIXED_ADVANCE_PC 1

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,0 +1,5 @@
+2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* elf/riscv.h: Added CORE-V hardware loop specific relocations.
+	* opcode/riscv.h: Added CORE-V hardware loop specific masks and
+	CORE-V instruction class.

--- a/include/elf/riscv.h
+++ b/include/elf/riscv.h
@@ -89,8 +89,8 @@ START_RELOC_NUMBERS (elf_riscv_reloc_type)
   RELOC_NUMBER (R_RISCV_SET32, 56)
   RELOC_NUMBER (R_RISCV_32_PCREL, 57)
   /* Pulp specific relocs */
-  RELOC_NUMBER (R_RISCV_REL12, 57)
-  RELOC_NUMBER (R_RISCV_RELU5, 58)
+  RELOC_NUMBER (R_RISCV_REL12, 58)
+  RELOC_NUMBER (R_RISCV_RELU5, 59)
 END_RELOC_NUMBERS (R_RISCV_max)
 
 /* Processor specific flags for the ELF header e_flags field.  */

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -101,6 +101,9 @@ static const char * const riscv_pred_succ[16] =
   ((RV_X(x, 3, 3) << 1) | (RV_X(x, 11, 1) << 4) | (RV_X(x, 2, 1) << 5) | (RV_X(x, 7, 1) << 6) | (RV_X(x, 6, 1) << 7) | (RV_X(x, 9, 2) << 8) | (RV_X(x, 8, 1) << 10) | (-RV_X(x, 12, 1) << 11))
 
 /* TODO (PULP): Add PULP ITYPEs */
+#define EXTRACT_I1TYPE_UIMM(x) \
+  (RV_X(x, 15, 5))
+
 #define ENCODE_ITYPE_IMM(x) \
   (RV_X(x, 0, 12) << 20)
 #define ENCODE_STYPE_IMM(x) \
@@ -141,6 +144,8 @@ static const char * const riscv_pred_succ[16] =
   ((RV_X(x, 1, 3) << 3) | (RV_X(x, 4, 1) << 11) | (RV_X(x, 5, 1) << 2) | (RV_X(x, 6, 1) << 7) | (RV_X(x, 7, 1) << 6) | (RV_X(x, 8, 2) << 9) | (RV_X(x, 10, 1) << 8) | (RV_X(x, 11, 1) << 12))
 
 /* TODO (PULP): Add PULP ITYPEs */
+#define ENCODE_I1TYPE_UIMM(x) \
+  (RV_X(x, 0, 5) << 15)
 
 #define VALID_ITYPE_IMM(x) (EXTRACT_ITYPE_IMM(ENCODE_ITYPE_IMM(x)) == (x))
 #define VALID_STYPE_IMM(x) (EXTRACT_STYPE_IMM(ENCODE_STYPE_IMM(x)) == (x))
@@ -163,6 +168,7 @@ static const char * const riscv_pred_succ[16] =
 #define VALID_RVC_J_IMM(x) (EXTRACT_RVC_J_IMM(ENCODE_RVC_J_IMM(x)) == (x))
 
 /* TODO (PULP): Add PULP ITYPEs */
+#define VALID_I1TYPE_UIMM(x) (EXTRACT_I1TYPE_UIMM(ENCODE_I1TYPE_UIMM(x)) == (x))
 
 #define RISCV_RTYPE(insn, rd, rs1, rs2) \
   ((MATCH_ ## insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2))
@@ -229,6 +235,10 @@ static const char * const riscv_pred_succ[16] =
 #define OP_SH_RL		25
 
 /* TODO (PULP): Add PULP MASKs */
+#define OP_MASK_IMM12           0xfff
+#define OP_SH_IMM12             20
+#define OP_MASK_IMM5            0x1f
+#define OP_SH_IMM5              15
 
 #define OP_MASK_CUSTOM_IMM	0x7f
 #define OP_SH_CUSTOM_IMM	25
@@ -316,11 +326,7 @@ enum riscv_insn_class
    INSN_CLASS_D_AND_C,
    INSN_CLASS_F_AND_C,
    INSN_CLASS_Q,
-   INSN_CLASS_P0,
-   INSN_CLASS_P1,
-   INSN_CLASS_P2,
-   INSN_CLASS_GAP,
-   INSN_CLASS_P3,
+   INSN_CLASS_COREV,
   };
 
 /* This structure holds information for a particular instruction.  */

--- a/ld/ChangeLog.COREV
+++ b/ld/ChangeLog.COREV
@@ -1,0 +1,3 @@
+2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* emultempl/riscvelf.em: Added CORE-V hardware loop support.

--- a/ld/emultempl/riscvelf.em
+++ b/ld/emultempl/riscvelf.em
@@ -25,16 +25,6 @@ fragment <<EOF
 #include "elf/riscv.h"
 #include "elfxx-riscv.h"
 
-#define _WITH_PULP_CHIP_INFO_FUNCT_
-
-static int TRACE = 0;
-
-static int Warn_Chip_Info = 0;
-static int Error_Chip_Info = 0;
-
-static struct Pulp_Target_Chip Pulp_Chip = {PULP_CHIP_NONE, PULP_NONE, -1, -1, -1, -1, -1};
-static struct Pulp_Target_Chip DefChipInfo = {PULP_CHIP_NONE, PULP_NONE, 0, 1, 1024*256, 64*1024, 0};
-
 static void
 riscv_elf_before_allocation (void)
 {

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,0 +1,4 @@
+2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* riscv-dis.c: Added CORE-V hardware loop support.
+	* riscv-opc.c: Added CORE-V hardware loop specific opcodes.

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -266,6 +266,16 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	  break;
 
 	case 'b':
+	  if (d[1]=='1') {
+             info->target = (EXTRACT_ITYPE_IMM (l)<<1) + pc; ++d;
+             (*info->print_address_func) (info->target, info);
+	     break;
+          } else if (d[1]=='2') {
+             info->target = (EXTRACT_I1TYPE_UIMM (l)<<1) + pc; ++d;
+             (*info->print_address_func) (info->target, info);
+	     break;
+          }
+	  /* Fall through.  */
 	case 's':
 	  if ((l & MASK_JALR) == MATCH_JALR)
 	    maybe_print_address (pd, rs1, 0);
@@ -301,6 +311,11 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	  maybe_print_address (pd, rs1, EXTRACT_ITYPE_IMM (l));
 	  /* Fall through.  */
 	case 'j':
+          if (d[1]=='i') {
+             ++d;
+             print (info->stream, "%d", (int) EXTRACT_ITYPE_IMM (l));
+             break;
+          }
 	  if (((l & MASK_ADDI) == MATCH_ADDI && rs1 != 0)
 	      || (l & MASK_JALR) == MATCH_JALR)
 	    maybe_print_address (pd, rs1, EXTRACT_ITYPE_IMM (l));
@@ -329,7 +344,11 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	    pd->hi_addr[rd] = EXTRACT_UTYPE_IMM (l);
 	  else if ((l & MASK_C_LUI) == MATCH_C_LUI)
 	    pd->hi_addr[rd] = EXTRACT_RVC_LUI_IMM (l);
-	  print (info->stream, "%s", riscv_gpr_names[rd]);
+          if (d[1]=='i') {
+             ++d;
+             print (info->stream, "x%d", (int) rd);
+          } else print (info->stream, "%s", riscv_gpr_names[rd]);
+
 	  break;
 
 	case 'z':

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -781,56 +781,15 @@ const struct riscv_opcode riscv_opcodes[] =
 {"wfi",        0, INSN_CLASS_I,   "",     MATCH_WFI, MASK_WFI, match_opcode, 0 },
 
 /* PULP specific opcodes */
-/* PULP v0 */
+/* TODO : COREV i.e. PULP v3 */
 /* Hardware loops */
 
-{"cv.starti", 0, "INSN_CLASS_P0", "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, "INSN_CLASS_P0", "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, "INSN_CLASS_P0", "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, "INSN_CLASS_P0", "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, "INSN_CLASS_P0", "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, "INSN_CLASS_P0", "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
-
-
-/* PULP v1 */
-/* Hardware loops */
-
-{"cv.starti", 0, "INSN_CLASS_P1", "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, "INSN_CLASS_P1", "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, "INSN_CLASS_P1", "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, "INSN_CLASS_P1", "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, "INSN_CLASS_P1", "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, "INSN_CLASS_P1", "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
-
-/* PULP v2 */
-/* Hardware loops */
-
-{"cv.starti", 0, "INSN_CLASS_P2", "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, "INSN_CLASS_P2", "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, "INSN_CLASS_P2", "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, "INSN_CLASS_P2", "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, "INSN_CLASS_P2", "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, "INSN_CLASS_P2", "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
-
-/* Gap8 */
-/* Hardware loops */
-
-{"cv.starti", 0, "INSN_CLASS_GAP", "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, "INSN_CLASS_GAP", "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, "INSN_CLASS_GAP", "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, "INSN_CLASS_GAP", "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, "INSN_CLASS_GAP", "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, "INSN_CLASS_GAP", "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
-
-/* PULP v3 */
-/* Hardware loops */
-
-{"cv.starti", 0, "INSN_CLASS_P3", "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, "INSN_CLASS_P3", "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, "INSN_CLASS_P3", "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, "INSN_CLASS_P3", "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, "INSN_CLASS_P3", "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, "INSN_CLASS_P3", "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
+{"cv.starti", 0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
+{"cv.endi",   0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
+{"cv.count",  0, INSN_CLASS_COREV, "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
+{"cv.counti", 0, INSN_CLASS_COREV, "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
+{"cv.setup",  0, INSN_CLASS_COREV, "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
+{"cv.setupi", 0, INSN_CLASS_COREV, "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
 
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}


### PR DESCRIPTION
Added relocations, masks, instruction class and opcodes to support CORE-V hardware loop instructions.

gas/ChangeLog.COREV:

        * config/tc-riscv.c: Added CORE-V harware loop support.
        * config/tc-riscv.h: Likewise.

bfd/ChangeLog.COREV:

        * bfd-in2.h: Added CORE-V hardware loop specific relocations.

include/ChangeLog.COREV:

        * elf/riscv.h: Added CORE-V hardware loop specific relocations.
        * opcode/riscv.h: Added CORE-V hardware loop specific masks and
        CORE-V instruction class.

ld/ChangeLog.COREV:

        * emultempl/riscvelf.em: Added CORE-V hardware loop support.

opcodes/ChangeLog.COREV:

        * riscv-dis.c: Added CORE-V hardware loop support.
        * riscv-opc.c: Added CORE-V hardware loop specific opcodes.
