### PR TITLE
Fixed loop number & unsigned immediate formats. Added GAS tests for hw loop.

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c: Changed loop number operand to be a non-register
+	type and corrected ranges in error messages.
+
 2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* config/tc-riscv.c: Added CORE-V harware loop support.

--- a/gas/testsuite/gas/riscv/cv-hwloop-01.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-01.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-01.s
+#error_output: cv-hwloop-01.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-01.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-01.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: -6 constant out of range for cv.starti/cv.endi/cv.setup, range:\[0, 4094\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-01.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-01.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 4094]  
+target:
+        cv.starti 0, -6

--- a/gas/testsuite/gas/riscv/cv-hwloop-02.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-02.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-02.s
+#error_output: cv-hwloop-02.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-02.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-02.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: 8900 constant out of range for cv.starti/cv.endi/cv.setup, range:\[0, 4094\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-02.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-02.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 4094] 
+target:
+        cv.starti 0, 8900

--- a/gas/testsuite/gas/riscv/cv-hwloop-03.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-03.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-03.s
+#warning_output: cv-hwloop-03.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-03.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-03.l
@@ -1,0 +1,2 @@
+.*Assembler messages:
+.*Warning: constant for cv.starti/cv.endi/cv.setup must be even: 105 truncated to 104

--- a/gas/testsuite/gas/riscv/cv-hwloop-03.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-03.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 4094]
+target:
+	cv.starti 0, 105

--- a/gas/testsuite/gas/riscv/cv-hwloop-04.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-04.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-04.s
+#error_output: cv-hwloop-04.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-04.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-04.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: -10 constant out of range for cv.setupi, range:\[0, 30\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-04.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-04.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 30] 
+target:
+	cv.setupi 0, 1056, -10

--- a/gas/testsuite/gas/riscv/cv-hwloop-05.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-05.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-05.s
+#error_output: cv-hwloop-05.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-05.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-05.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: 340 constant out of range for cv.setupi, range:\[0, 30\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-05.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-05.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 30] 
+target:
+	cv.setupi 0, 1056, 340

--- a/gas/testsuite/gas/riscv/cv-hwloop-06.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-06.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-06.s
+#warning_output: cv-hwloop-06.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-06.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-06.l
@@ -1,0 +1,2 @@
+.*Assembler messages:
+.*Warning: constant for cv.setupi must be even: 19 truncated to 18

--- a/gas/testsuite/gas/riscv/cv-hwloop-06.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-06.s
@@ -1,0 +1,3 @@
+#Branch offset must be an even integer in range:[0, 30]
+target:
+	cv.setupi 0, 1056, 19

--- a/gas/testsuite/gas/riscv/cv-hwloop-07.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-07.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-07.s
+#error_output: cv-hwloop-07.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-07.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-07.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: loop number must be 0 or 1 not -50

--- a/gas/testsuite/gas/riscv/cv-hwloop-07.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-07.s
@@ -1,0 +1,3 @@
+#Loop number must be 0 or 1 
+target:
+        cv.starti -50, 104

--- a/gas/testsuite/gas/riscv/cv-hwloop-08.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-08.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-08.s
+#error_output: cv-hwloop-08.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-08.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-08.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: loop number must be 0 or 1 not 700

--- a/gas/testsuite/gas/riscv/cv-hwloop-08.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-08.s
@@ -1,0 +1,3 @@
+#Loop number must be 0 or 1
+target:
+        cv.starti 700, 104

--- a/gas/testsuite/gas/riscv/cv-hwloop-count.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-count.d
@@ -1,0 +1,12 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0002a07b[ 	]+cv.count[ 	]+0,t0
+[ 	]+4:[ 	]+0005a0fb[ 	]+cv.count[ 	]+1,a1
+[ 	]+8:[ 	]+000ea07b[ 	]+cv.count[ 	]+0,t4

--- a/gas/testsuite/gas/riscv/cv-hwloop-count.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-count.s
@@ -1,0 +1,4 @@
+target:
+	cv.count 0, t0
+	cv.count 1, a1
+	cv.count 0, t4

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.d
@@ -1,0 +1,13 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0000307b[ 	]+cv.counti[ 	]+0,0
+[ 	]+4:[ 	]+791030fb[ 	]+cv.counti[ 	]+1,1937
+[ 	]+8:[ 	]+fff0307b[ 	]+cv.counti[ 	]+0,4095
+[ 	]+c:[ 	]+7ff030fb[ 	]+cv.counti[ 	]+1,2047

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.s
@@ -1,0 +1,5 @@
+target:
+	cv.counti 0, 0
+	cv.counti 1, 1937
+	cv.counti 0, 4095 /* we get negative */
+	cv.counti 1, 2047 /* is this the real max */

--- a/gas/testsuite/gas/riscv/cv-hwloop-endi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-endi.d
@@ -1,0 +1,12 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0000107b[ 	]+cv.endi[ 	]+0,0 <target>
+[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
+[ 	]+8:[ 	]+7ff0107b[ 	]+cv.endi[ 	]+0,1006 +<target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwloop-endi.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-endi.s
@@ -1,0 +1,4 @@
+target:
+	cv.endi 0, 0
+	cv.endi 1, 1056
+	cv.endi 0, 4094

--- a/gas/testsuite/gas/riscv/cv-hwloop-setup.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setup.d
@@ -1,0 +1,12 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0002c07b[ 	]+cv.setup[ 	]+0,t0,0 <target>
+[ 	]+4:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,1ec <target\+0x1ec>
+[ 	]+8:[ 	]+7ff5407b[ 	]+cv.setup[ 	]+0,a0,1006 <target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwloop-setup.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setup.s
@@ -1,0 +1,4 @@
+target:
+	cv.setup 0, t0, 0
+        cv.setup 1, t5, 488
+	cv.setup 0, a0, 4094

--- a/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
@@ -1,0 +1,12 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0000507b[ 	]+cv.setupi[ 	]+0,0,0 <target>
+[ 	]+4:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,10 <target\+0x10>
+[ 	]+8:[ 	]+fff7d07b[ 	]+cv.setupi[ 	]+0,4095,26 <target\+0x26>

--- a/gas/testsuite/gas/riscv/cv-hwloop-setupi.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setupi.s
@@ -1,0 +1,4 @@
+target:
+	cv.setupi 0, 0, 0
+        cv.setupi 1, 488, 12
+	cv.setupi 0, 4095, 30

--- a/gas/testsuite/gas/riscv/cv-hwloop-starti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-starti.d
@@ -1,0 +1,12 @@
+#as: -march=rv32ixpulpv3
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0000007b[ 	]+cv.starti[ 	]+0,0 <target>
+[ 	]+4:[ 	]+5e6000fb[ 	]+cv.starti[ 	]+1,bd0 +<target\+0xbd0>
+[ 	]+8:[ 	]+7ff0007b[ 	]+cv.starti[ 	]+0,1006 +<target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwloop-starti.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-starti.s
@@ -1,0 +1,4 @@
+target:
+	cv.starti 0, 0
+	cv.starti 1, 3020
+	cv.starti 0, 4094

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* opcode/riscv.h: Added macros for unsigned I type immediate and loop number. 
+
+
 2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* elf/riscv.h: Added CORE-V hardware loop specific relocations.

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -103,6 +103,11 @@ static const char * const riscv_pred_succ[16] =
 /* TODO (PULP): Add PULP ITYPEs */
 #define EXTRACT_I1TYPE_UIMM(x) \
   (RV_X(x, 15, 5))
+#define EXTRACT_I1TYPE_UIMM1(x) \
+  (RV_X(x, 7, 1))
+/* TODO : SEE IF YOU CAN CHANGED ANYWHERE THAT IS ji to this extract for consistency*/
+#define EXTRACT_ITYPE_UIMM(x) \
+  (RV_X(x, 20, 12))
 
 #define ENCODE_ITYPE_IMM(x) \
   (RV_X(x, 0, 12) << 20)
@@ -146,6 +151,9 @@ static const char * const riscv_pred_succ[16] =
 /* TODO (PULP): Add PULP ITYPEs */
 #define ENCODE_I1TYPE_UIMM(x) \
   (RV_X(x, 0, 5) << 15)
+#define ENCODE_I1TYPE_UIMM1(x) \
+  (RV_X(x, 0, 1) << 7)
+
 
 #define VALID_ITYPE_IMM(x) (EXTRACT_ITYPE_IMM(ENCODE_ITYPE_IMM(x)) == (x))
 #define VALID_STYPE_IMM(x) (EXTRACT_STYPE_IMM(ENCODE_STYPE_IMM(x)) == (x))
@@ -169,6 +177,7 @@ static const char * const riscv_pred_succ[16] =
 
 /* TODO (PULP): Add PULP ITYPEs */
 #define VALID_I1TYPE_UIMM(x) (EXTRACT_I1TYPE_UIMM(ENCODE_I1TYPE_UIMM(x)) == (x))
+#define VALID_I1TYPE_UIMM1(x) (EXTRACT_I1TYPE_UIMM1(ENCODE_I1TYPE_UIMM1(x)) == (x))
 
 #define RISCV_RTYPE(insn, rd, rs1, rs2) \
   ((MATCH_ ## insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2))
@@ -239,6 +248,8 @@ static const char * const riscv_pred_succ[16] =
 #define OP_SH_IMM12             20
 #define OP_MASK_IMM5            0x1f
 #define OP_SH_IMM5              15
+#define OP_MASK_IMM1            0x1  // TODO: ADDED BY JM//
+#define OP_SH_IMM1              7
 
 #define OP_MASK_CUSTOM_IMM	0x7f
 #define OP_SH_CUSTOM_IMM	25

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* riscv-dis.c: Changed macro used to print unsigned I type immediate and
+	changed printing of loop number to non-register type.
+
 2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* riscv-dis.c: Added CORE-V hardware loop support.

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -313,7 +313,7 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	case 'j':
           if (d[1]=='i') {
              ++d;
-             print (info->stream, "%d", (int) EXTRACT_ITYPE_IMM (l));
+             print (info->stream, "%d", (int) EXTRACT_ITYPE_UIMM (l));
              break;
           }
 	  if (((l & MASK_ADDI) == MATCH_ADDI && rs1 != 0)
@@ -346,7 +346,7 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	    pd->hi_addr[rd] = EXTRACT_RVC_LUI_IMM (l);
           if (d[1]=='i') {
              ++d;
-             print (info->stream, "x%d", (int) rd);
+             print (info->stream, "%d", (int) rd);
           } else print (info->stream, "%s", riscv_gpr_names[rd]);
 
 	  break;


### PR DESCRIPTION
        Fixed the loop number to be recognised as a non-register type. Fixed unsigned immediate to be printed as an unsigned 12-bit integer.
	Added GAS tests for hardware loop.

gas/ChangeLog.COREV:

        * config/tc-riscv.c: Changed loop number operand to be a non-register
        type and corrected ranges in error messages.

include/ChangeLog.COREV:

        * opcode/riscv.h: Added macros for unsigned I type immediate and loop number.

opcodes/ChangeLog.COREV:

        * riscv-dis.c: Changed macro used to print unsigned I type immediate and
        changed printing of loop number to non-register type.

gas/testsuite/gas/riscv:
	* cv-hwloop-01.d: Created.
	* cv-hwloop-01.l: Created.
	* cv-hwloop-01.s: Created.
	* cv-hwloop-02.d: Created.
	* cv-hwloop-02.l: Created.
	* cv-hwloop-02.s: Created.
	* cv-hwloop-03.d: Created.
	* cv-hwloop-03.l: Created.
	* cv-hwloop-03.s: Created.
	* cv-hwloop-04.d: Created.
	* cv-hwloop-04.l: Created.
	* cv-hwloop-04.s: Created.
	* cv-hwloop-05.d: Created.
	* cv-hwloop-05.l: Created.
	* cv-hwloop-05.s: Created.
	* cv-hwloop-06.d: Created.
	* cv-hwloop-06.l: Created.
	* cv-hwloop-06.s: Created.
	* cv-hwloop-07.d: Created.
	* cv-hwloop-07.l: Created.
	* cv-hwloop-07.s: Created.
	* cv-hwloop-08.d: Created.
	* cv-hwloop-08.l: Created.
	* cv-hwloop-08.s: Created.
	* cv-hwloop-count.d: Created.
	* cv-hwloop-count.s: Created.
	* cv-hwloop-counti.d: Created.
	* cv-hwloop-counti.s: Created.
	* cv-hwloop-endi.d: Created.
	* cv-hwloop-endi.s: Created.
	* cv-hwloop-setup.d: Created.
	* cv-hwloop-setup.s: Created.
	* cv-hwloop-setupi.d: Created.
	* cv-hwloop-setupi.s: Created.
	* cv-hwloop-starti.d: Created.
	* cv-hwloop-starti.s: Created.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>