### PR TITLE
Added tests for uimmL. Fixed ChangeLog errors. Renamed macros.

### DIFF
--- a/bfd/ChangeLog
+++ b/bfd/ChangeLog
@@ -1,8 +1,3 @@
-2020-08-21  Mary Bennett <mary.bennett@embecosm.com>
-
-	* elfnn-riscv.c: Added relocations for PULP hardware loop.
-	* elfxx-riscv.c: Likewise.
-
 2020-08-15  Alan Modra  <amodra@gmail.com>
 
 	* elf32-frv.c (elf32_frv_add_symbol_hook): Set SEC_SMALL_DATA on

--- a/bfd/ChangeLog.COREV
+++ b/bfd/ChangeLog.COREV
@@ -1,3 +1,8 @@
 2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* bfd-in2.h: Added CORE-V hardware loop specific relocations.
+
+2020-08-21  Mary Bennett <mary.bennett@embecosm.com>
+
+	* elfnn-riscv.c: Added relocations for PULP hardware loop.
+	* elfxx-riscv.c: Likewise.

--- a/gas/ChangeLog
+++ b/gas/ChangeLog
@@ -1,9 +1,3 @@
-2020-08-21  Mary Bennett  <mary.bennett@embecosm.com>
-
-	* config/tc-riscv.c: Added initial PULP support and instruction
-	classes. 
-	* config/tc-riscv.h: Likewise. 
-
 2020-08-17  Alex Coplan  <alex.coplan@arm.com>
 
 	* config/obj-elf.c (obj_elf_change_section): When repurposing an

--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,5 +1,9 @@
 2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
 
+	* config/tc-riscv.c: Corrected unsigned immediate error message.
+
+2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
+
 	* config/tc-riscv.c: Changed loop number operand to be a non-register
 	type and corrected ranges in error messages.
 

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -953,7 +953,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
       case 'T':	USE_BITS (OP_MASK_RS2,		OP_SH_RS2);	break;
       case 'd':
 	if (*p == 'i') { /* TODO : CHANGE THIS */
-          used_bits |= ( 0xf00 |(ENCODE_I1TYPE_UIMM1(-1U))); /* Bits 11:08 preset to 0 */
+          used_bits |= ( 0xf00 |(ENCODE_I1TYPE_LN(-1U))); /* Bits 11:08 preset to 0 */
           ++p; break;
 	}
 	USE_BITS (OP_MASK_RD,		OP_SH_RD);	 break;
@@ -2431,11 +2431,10 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
                 my_getExpression (imm_expr, s);
                 check_absolute_expr (ip, imm_expr, FALSE); /* TODO : MADE THIS FALSE? */
                 s = expr_end;
-                if (imm_expr->X_op != O_constant || imm_expr->X_add_number >= (signed)RISCV_IMM_REACH ||
+                if (imm_expr->X_op != O_constant || imm_expr->X_add_number >= (int) RISCV_IMM_REACH ||
                     imm_expr->X_add_number < 0)
-                        as_fatal (_("internal error: non constant or too large lsetupi loop count %s, range:[0, %d["),
-                                  saved_s, (int) RISCV_IMM_REACH);
-
+                        as_fatal (_("internal error: %d constant out of range for cv.counti/cv.setupi, range:[0, %d]"),
+                                  imm_expr->X_add_number, ((int) RISCV_IMM_REACH) -1);
                 INSERT_OPERAND (IMM12, *ip, imm_expr->X_add_number);
                 continue;
               } else {

--- a/gas/testsuite/gas/riscv/cv-hwloop-09.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-09.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-09.s
+#error_output: cv-hwloop-09.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-09.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-09.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: -900 constant out of range for cv.counti/cv.setupi, range:\[0, 4095\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-09.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-09.s
@@ -1,0 +1,3 @@
+#Loop count must be positive integer in range:[0, 4094]
+target:
+	cv.setupi 0, -900, 5

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.d
@@ -1,0 +1,3 @@
+#as: -march=rv32ixpulpv3
+#source: cv-hwloop-10.s
+#error_output: cv-hwloop-10.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Fatal error: internal error: 9000 constant out of range for cv.counti/cv.setupi, range:\[0, 4095\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.s
@@ -1,0 +1,3 @@
+#Loop count must be positive integer in range:[0, 4094]
+target:
+	cv.setupi 0, 9000, 5

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.d
@@ -10,4 +10,3 @@ Disassembly of section .text:
 [ 	]+0:[ 	]+0000307b[ 	]+cv.counti[ 	]+0,0
 [ 	]+4:[ 	]+791030fb[ 	]+cv.counti[ 	]+1,1937
 [ 	]+8:[ 	]+fff0307b[ 	]+cv.counti[ 	]+0,4095
-[ 	]+c:[ 	]+7ff030fb[ 	]+cv.counti[ 	]+1,2047

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.s
@@ -1,5 +1,4 @@
 target:
 	cv.counti 0, 0
 	cv.counti 1, 1937
-	cv.counti 0, 4095 /* we get negative */
-	cv.counti 1, 2047 /* is this the real max */
+	cv.counti 0, 4095

--- a/include/ChangeLog
+++ b/include/ChangeLog
@@ -1,9 +1,3 @@
-2020-08-21  Mary Bennett  <mary.bennett@embecosm.com>
-
-	* elf/riscv.h: Added initial PULP support.
-	* opcode/riscv-opc.h: Likewise.
-	* opcode/riscv.h: Likewise.
-
 2020-08-10  Alex Coplan  <alex.coplan@arm.com>
 
 	* opcode/aarch64.h (AARCH64_MAX_SYSREG_NAME_LEN): New.

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,10 +1,18 @@
+2020-09-09  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* opcode/riscv.h: Changed macro names for loop number and removed
+	unused VALID macros.
+
 2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* opcode/riscv.h: Added macros for unsigned I type immediate and loop number. 
-
+	* opcode/riscv.h: Added macros for unsigned I type immediate and loop number.
 
 2020-08-28  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* elf/riscv.h: Added CORE-V hardware loop specific relocations.
 	* opcode/riscv.h: Added CORE-V hardware loop specific masks and
 	CORE-V instruction class.
+
+2020-08-21  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* opcode/riscv-opc.h: Added CORE-V support.

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -103,7 +103,7 @@ static const char * const riscv_pred_succ[16] =
 /* TODO (PULP): Add PULP ITYPEs */
 #define EXTRACT_I1TYPE_UIMM(x) \
   (RV_X(x, 15, 5))
-#define EXTRACT_I1TYPE_UIMM1(x) \
+#define EXTRACT_I1TYPE_LN(x) \
   (RV_X(x, 7, 1))
 /* TODO : SEE IF YOU CAN CHANGED ANYWHERE THAT IS ji to this extract for consistency*/
 #define EXTRACT_ITYPE_UIMM(x) \
@@ -151,7 +151,7 @@ static const char * const riscv_pred_succ[16] =
 /* TODO (PULP): Add PULP ITYPEs */
 #define ENCODE_I1TYPE_UIMM(x) \
   (RV_X(x, 0, 5) << 15)
-#define ENCODE_I1TYPE_UIMM1(x) \
+#define ENCODE_I1TYPE_LN(x) \
   (RV_X(x, 0, 1) << 7)
 
 
@@ -175,9 +175,6 @@ static const char * const riscv_pred_succ[16] =
 #define VALID_RVC_B_IMM(x) (EXTRACT_RVC_B_IMM(ENCODE_RVC_B_IMM(x)) == (x))
 #define VALID_RVC_J_IMM(x) (EXTRACT_RVC_J_IMM(ENCODE_RVC_J_IMM(x)) == (x))
 
-/* TODO (PULP): Add PULP ITYPEs */
-#define VALID_I1TYPE_UIMM(x) (EXTRACT_I1TYPE_UIMM(ENCODE_I1TYPE_UIMM(x)) == (x))
-#define VALID_I1TYPE_UIMM1(x) (EXTRACT_I1TYPE_UIMM1(ENCODE_I1TYPE_UIMM1(x)) == (x))
 
 #define RISCV_RTYPE(insn, rd, rs1, rs2) \
   ((MATCH_ ## insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2))

--- a/ld/ChangeLog
+++ b/ld/ChangeLog
@@ -1,7 +1,3 @@
-2020-08-21  Mary Bennett  <mary.bennett@embecosm.com>
-
-	* emultempl/riscvelf.em: Added initial PULP support.
-
 2020-08-16  Alan Modra  <amodra@gmail.com>
 
 	* testsuite/ld-powerpc/inline.s,

--- a/opcodes/ChangeLog
+++ b/opcodes/ChangeLog
@@ -1,7 +1,3 @@
-2020-08-21  Mary Bennett  <mary.bennett@embecosm.com>
-
-	* riscv-opc.c (riscv_opcodes): Added PULP hardware loop instructions.
-
 2020-08-12  Alex Coplan  <alex.coplan@arm.com>
 
 	* aarch64-opc.c (aarch64_sys_regs): Add MPAM registers.


### PR DESCRIPTION
        Fixed error message for cv.setupi/cv.counti long unsigned immediate and created tests. Moved Mary's ChangeLog additions to ChangeLog.COREV. Renamed macros for loop number from UIMM1 to LN.

Files changed:

        bfd/ChangeLog: Removed Mary's additions.
        bfd/ChangeLog.COREV: Added Mary's additions.
        gas/ChangeLog: Removed Mary's additions.
        gas/ChangeLog.COREV: Added Mary's additions.
        gas/config/tc-riscv.c: Fixed incorrect error message.
        include/ChangeLog: Removed Mary's additions.
        include/ChangeLog.COREV: Added Mary's additions.
        include/opcode/riscv.h: Renamed macros for loop number.
        ld/ChangeLog: Removed Mary's additions.
        opcodes/ChangeLog: Removed Mary's additions.
        gas/testsuite/gas/riscv/cv-hwloop-09.d: Created.
        gas/testsuite/gas/riscv/cv-hwloop-09.l: Created.
        gas/testsuite/gas/riscv/cv-hwloop-09.s: Created.
        gas/testsuite/gas/riscv/cv-hwloop-10.d: Created.
        gas/testsuite/gas/riscv/cv-hwloop-10.l: Created.
        gas/testsuite/gas/riscv/cv-hwloop-10.s: Created.
