### PR TITLE
Changed the architecture from xpulpv3 to xcorev

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,23 @@
+2020-09-09  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* gas/config/tc-riscv.c: Changed xpulpv to xcorev.
+	* gas/testsuite/gas/riscv/cv-hwloop-01.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-02.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-03.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-04.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-05.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-06.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-07.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-08.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-09.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-10.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-count.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-counti.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-endi.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-setup.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-setupi.d: Same.
+	* gas/testsuite/gas/riscv/cv-hwloop-starti.d: Same.
+
 2020-09-07  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* config/tc-riscv.c: Corrected unsigned immediate error message.

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -229,8 +229,8 @@ riscv_multi_subset_supports (enum riscv_insn_class insn_class)
     case INSN_CLASS_D: return riscv_subset_supports ("d");
     case INSN_CLASS_D_AND_C:
       return riscv_subset_supports ("d") && riscv_subset_supports ("c");
-    /* TODO : CHANGE TO COREV */
-    case INSN_CLASS_COREV:  return riscv_subset_supports ("xpulpv");
+
+    case INSN_CLASS_COREV:  return riscv_subset_supports ("xcorev");
     case INSN_CLASS_F_AND_C:
       return riscv_subset_supports ("f") && riscv_subset_supports ("c");
 

--- a/gas/testsuite/gas/riscv/cv-hwloop-01.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-01.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-01.s
 #error_output: cv-hwloop-01.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-02.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-02.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-02.s
 #error_output: cv-hwloop-02.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-03.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-03.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-03.s
 #warning_output: cv-hwloop-03.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-04.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-04.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-04.s
 #error_output: cv-hwloop-04.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-05.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-05.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-05.s
 #error_output: cv-hwloop-05.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-06.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-06.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-06.s
 #warning_output: cv-hwloop-06.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-07.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-07.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-07.s
 #error_output: cv-hwloop-07.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-08.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-08.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-08.s
 #error_output: cv-hwloop-08.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-09.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-09.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-09.s
 #error_output: cv-hwloop-09.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #source: cv-hwloop-10.s
 #error_output: cv-hwloop-10.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-count.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-count.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-endi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-endi.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-setup.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setup.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-starti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-starti.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/ld/ChangeLog.COREV
+++ b/ld/ChangeLog.COREV
@@ -1,5 +1,16 @@
 2020-09-09  Mary Bennett  <mary.bennett@embecosm.com>
 
+	* ld/testsuite/ld-riscv-elf/cv-endi.d: Changed xpulpv3 to xcorev.
+	* ld/testsuite/ld-riscv-elf/cv-endi.s: Same.
+	* ld/testsuite/ld-riscv-elf/cv-setup.d: Same.
+	* ld/testsuite/ld-riscv-elf/cv-setup.s: Same.
+	* ld/testsuite/ld-riscv-elf/cv-setupi.d: Same.
+	* ld/testsuite/ld-riscv-elf/cv-setupi.s: Same.
+	* ld/testsuite/ld-riscv-elf/cv-starti.d: Same.
+	* ld/testsuite/ld-riscv-elf/cv-starti.s: Same.
+
+2020-09-09  Mary Bennett  <mary.bennett@embecosm.com>
+
 	* ld/testsuite/ld-riscv-elf/cv-endi.d: Added new test.
 	* ld/testsuite/ld-riscv-elf/cv-endi.s: Same.
 	* ld/testsuite/ld-riscv-elf/cv-setup.d: Same.

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-endi.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-endi.d
@@ -1,6 +1,6 @@
 #name: endi relaxation
 #source: cv-hwloop-endi.s
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-setup.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-setup.d
@@ -1,6 +1,6 @@
 #name: setup relaxation
 #source: cv-hwloop-setup.s
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-setupi.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-setupi.d
@@ -1,6 +1,6 @@
 #name: setupi relaxation
 #source: cv-hwloop-setupi.s
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-starti.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-starti.d
@@ -1,6 +1,6 @@
 #name: starti relaxation
 #source: cv-hwloop-starti.s
-#as: -march=rv32ixpulpv3
+#as: -march=rv32i_xcorev
 #ld: -melf32lriscv
 #objdump: -dr
 


### PR DESCRIPTION
gas/ChangeLog.CORE:

        * gas/config/tc-riscv.c: Changed xpulpv to xcorev.
        * gas/testsuite/gas/riscv/cv-hwloop-01.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-02.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-03.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-04.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-05.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-06.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-07.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-08.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-09.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-10.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-count.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-counti.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-endi.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-setup.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-setupi.d: Same.
        * gas/testsuite/gas/riscv/cv-hwloop-starti.d: Same.

ld/ChangeLog.CORE:

        * ld/testsuite/ld-riscv-elf/cv-endi.d: Changed xpulpv3 to xcorev.
        * ld/testsuite/ld-riscv-elf/cv-endi.s: Same.
        * ld/testsuite/ld-riscv-elf/cv-setup.d: Same.
        * ld/testsuite/ld-riscv-elf/cv-setup.s: Same.
        * ld/testsuite/ld-riscv-elf/cv-setupi.d: Same.
        * ld/testsuite/ld-riscv-elf/cv-setupi.s: Same.
        * ld/testsuite/ld-riscv-elf/cv-starti.d: Same.
        * ld/testsuite/ld-riscv-elf/cv-starti.s: Same.