### PR TITLE
Fixed incorrect CORE-V hwlp masks

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-10-05  Jessica Mills <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
+	hardware loop masks.
+
 2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
 
 	* config/tc-riscv.c: Tidied up CORE-V specific relocations.

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -962,7 +962,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
       case 'd':
 	if (*p == 'i')
 	  {
-	    used_bits |= (0xf00 |(ENCODE_I1TYPE_LN(-1U))); /* Bits 11:08 preset to 0 */
+	    used_bits |= ENCODE_I1TYPE_LN(-1U); /* Bits 11:08 preset to 0 */
 	    ++p;
 	    break;
 	  }

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-10-05  Jessica Mills <jessica.mills@embecosm.com>
+
+	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
+	instructions.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* elf/riscv.h: Added CORE-V hardware loop specific relocations.

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -853,12 +853,12 @@
 
 /* CORE-V Specific Instructions  */
 /* Hardware loops  */
-#define MASK_HWLP_STARTI 0x000ff07f
-#define MASK_HWLP_ENDI   0x000ff07f
-#define MASK_HWLP_COUNT  0xfff0707f
-#define MASK_HWLP_COUNTI 0x000ff07f
-#define MASK_HWLP_SETUP  0x0000707f
-#define MASK_HWLP_SETUPI 0x0000707f
+#define MASK_HWLP_STARTI 0x000fff7f
+#define MASK_HWLP_ENDI   0x000fff7f
+#define MASK_HWLP_COUNT  0xfff07f7f
+#define MASK_HWLP_COUNTI 0x000fff7f
+#define MASK_HWLP_SETUP  0x00007f7f
+#define MASK_HWLP_SETUPI 0x00007f7f
 
 #define MATCH_HWLP_STARTI 0x0007b
 #define MATCH_HWLP_ENDI   0x0107b


### PR DESCRIPTION
Files changed:

	* include/opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
        instructions.
	* gas/config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
        hardware loop masks.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>