### PR TITLE
Fixed incorrect CORE-V hwlp masks

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
+
+	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
+	hardware loop masks and added support for xcorevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* config/tc-riscv.c: Added CORE-V harware loop support.

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -242,7 +242,8 @@ riscv_multi_subset_supports (enum riscv_insn_class insn_class)
 
     case INSN_CLASS_Q: return riscv_subset_supports ("q");
 
-    case INSN_CLASS_COREV: return riscv_subset_supports ("xcorev");
+    case INSN_CLASS_COREV_HWLP:
+      return riscv_subset_supports ("xcorevhwlp") || riscv_subset_supports ("xcorev");
 
     default:
       as_fatal ("Unreachable");
@@ -962,7 +963,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
       case 'd':
 	if (*p == 'i')
 	  {
-	    used_bits |= (0xf00 |(ENCODE_I1TYPE_LN(-1U))); /* Bits 11:08 preset to 0 */
+	    used_bits |= ENCODE_I1TYPE_LN(-1U);
 	    ++p;
 	    break;
 	  }

--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,24 @@
+2020-10-21  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* gas/riscv/cv-hwloop-01.d: Changed march option to xcorehwlp.
+	* gas/riscv/cv-hwloop-02.d: Likewise.
+	* gas/riscv/cv-hwloop-03.d: Likewise.
+	* gas/riscv/cv-hwloop-04.d: Likewise.
+	* gas/riscv/cv-hwloop-05.d: Likewise.
+	* gas/riscv/cv-hwloop-06.d: Likewise.
+	* gas/riscv/cv-hwloop-07.d: Likewise.
+	* gas/riscv/cv-hwloop-08.d: Likewise.
+	* gas/riscv/cv-hwloop-count.d: Likewise.
+	* gas/riscv/cv-hwloop-counti.d: Likewise.
+	* gas/riscv/cv-hwloop-endi.d: Likewise.
+	* gas/riscv/cv-hwloop-setup.d: Likewise.
+	* gas/riscv/cv-hwloop-setupi.d: Likewise.
+	* gas/riscv/cv-hwloop-starti.d: Likewise.
+	* gas/riscv/cv-hwloop-09.d: Likewise.
+	* gas/riscv/cv-hwloop-10.d: Likewise.
+	* gas/riscv/cv-march-rv32i-xcorev.s: Added test for march option.
+	* gas/riscv/cv-march-rv32i-xcorev.d: Likewise.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* gas/riscv/cv-hwloop-01.d: Added new test.

--- a/gas/testsuite/gas/riscv/cv-hwloop-01.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-01.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-01.s
 #error_output: cv-hwloop-01.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-02.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-02.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-02.s
 #error_output: cv-hwloop-02.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-03.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-03.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-03.s
 #warning_output: cv-hwloop-03.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-04.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-04.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-04.s
 #error_output: cv-hwloop-04.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-05.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-05.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-05.s
 #error_output: cv-hwloop-05.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-06.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-06.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-06.s
 #warning_output: cv-hwloop-06.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-07.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-07.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-07.s
 #error_output: cv-hwloop-07.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-08.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-08.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-08.s
 #error_output: cv-hwloop-08.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-09.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-09.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-09.s
 #error_output: cv-hwloop-09.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #source: cv-hwloop-10.s
 #error_output: cv-hwloop-10.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-count.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-count.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-counti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-counti.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-endi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-endi.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-setup.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setup.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-setupi.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-hwloop-starti.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-starti.d
@@ -1,4 +1,4 @@
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #objdump: -d
 
 .*:[ 	]+file format .*

--- a/gas/testsuite/gas/riscv/cv-march-rv32i-xcorev.d
+++ b/gas/testsuite/gas/riscv/cv-march-rv32i-xcorev.d
@@ -1,0 +1,10 @@
+#as: -march=rv32i_xcorevhwlp
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+0a0000fb[ 	]+cv.starti[ 	]+1,140 +<target\+0x140>

--- a/gas/testsuite/gas/riscv/cv-march-rv32i-xcorev.s
+++ b/gas/testsuite/gas/riscv/cv-march-rv32i-xcorev.s
@@ -1,0 +1,3 @@
+# Testing xcorev march option works for all
+target:
+	cv.starti 1, 320

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,9 @@
+2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
+
+	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
+	instructions.
+	* opcode/riscv.h: Added support for xcorevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* elf/riscv.h: Added CORE-V hardware loop specific relocations.

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -853,12 +853,12 @@
 
 /* CORE-V Specific Instructions  */
 /* Hardware loops  */
-#define MASK_HWLP_STARTI 0x000ff07f
-#define MASK_HWLP_ENDI   0x000ff07f
-#define MASK_HWLP_COUNT  0xfff0707f
-#define MASK_HWLP_COUNTI 0x000ff07f
-#define MASK_HWLP_SETUP  0x0000707f
-#define MASK_HWLP_SETUPI 0x0000707f
+#define MASK_HWLP_STARTI 0x000fff7f
+#define MASK_HWLP_ENDI   0x000fff7f
+#define MASK_HWLP_COUNT  0xfff07f7f
+#define MASK_HWLP_COUNTI 0x000fff7f
+#define MASK_HWLP_SETUP  0x00007f7f
+#define MASK_HWLP_SETUPI 0x00007f7f
 
 #define MATCH_HWLP_STARTI 0x0007b
 #define MATCH_HWLP_ENDI   0x0107b

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -338,7 +338,7 @@ enum riscv_insn_class
    INSN_CLASS_D_AND_C,
    INSN_CLASS_F_AND_C,
    INSN_CLASS_Q,
-   INSN_CLASS_COREV,
+   INSN_CLASS_COREV_HWLP,
   };
 
 /* This structure holds information for a particular instruction.  */

--- a/ld/testsuite/ChangeLog.COREV
+++ b/ld/testsuite/ChangeLog.COREV
@@ -1,3 +1,10 @@
+2020-10-21  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* ld-riscv-elf/cv-hwloop-starti.d: Changed march option to xcorevhwlp.
+	* ld-riscv-elf/cv-hwloop-endi.d: Likewise.
+	* ld-riscv-elf/cv-hwloop-setup.d: Likewise.
+	* ld-riscv-elf/cv-hwloop-setupi.d: Likewise.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* ld-riscv-elf/ld-riscv-elf.exp: Added CORE-V hardware loop

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-endi.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-endi.d
@@ -1,6 +1,6 @@
 #name: endi relocation
 #source: cv-hwloop-endi.s
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-setup.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-setup.d
@@ -1,6 +1,6 @@
 #name: setup relocation
 #source: cv-hwloop-setup.s
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-setupi.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-setupi.d
@@ -1,6 +1,6 @@
 #name: setupi relocation
 #source: cv-hwloop-setupi.s
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/ld/testsuite/ld-riscv-elf/cv-hwloop-starti.d
+++ b/ld/testsuite/ld-riscv-elf/cv-hwloop-starti.d
@@ -1,6 +1,6 @@
 #name: starti relocation
 #source: cv-hwloop-starti.s
-#as: -march=rv32i_xcorev
+#as: -march=rv32i_xcorevhwlp
 #ld: -melf32lriscv
 #objdump: -dr
 

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,7 @@
+2020-10-08  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* riscv-opc.c: Added support for corevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* riscv-dis.c: Added CORE-V hardware loop support.

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -789,12 +789,12 @@ const struct riscv_opcode riscv_opcodes[] =
 
 /* CORE-V Specific Opcodes.  */
 /* Hardware loops  */
-{"cv.starti", 0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, INSN_CLASS_COREV, "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, INSN_CLASS_COREV, "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, INSN_CLASS_COREV, "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, INSN_CLASS_COREV, "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
+{"cv.starti", 0, INSN_CLASS_COREV_HWLP, "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
+{"cv.endi",   0, INSN_CLASS_COREV_HWLP, "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
+{"cv.count",  0, INSN_CLASS_COREV_HWLP, "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
+{"cv.counti", 0, INSN_CLASS_COREV_HWLP, "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
+{"cv.setup",  0, INSN_CLASS_COREV_HWLP, "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
+{"cv.setupi", 0, INSN_CLASS_COREV_HWLP, "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
 
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}


### PR DESCRIPTION
gas/ChangeLog.COREV:

	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
        hardware loop masks and added support for xcorevhwlp.

gas/testsuite/ChangeLog.COREV:

        * gas/riscv/cv-hwloop-01.d: Changed march option to xcorehwlp.
        * gas/riscv/cv-hwloop-02.d: Likewise.
        * gas/riscv/cv-hwloop-03.d: Likewise.
        * gas/riscv/cv-hwloop-04.d: Likewise.
        * gas/riscv/cv-hwloop-05.d: Likewise.
        * gas/riscv/cv-hwloop-06.d: Likewise.
        * gas/riscv/cv-hwloop-07.d: Likewise.
        * gas/riscv/cv-hwloop-08.d: Likewise.
        * gas/riscv/cv-hwloop-count.d: Likewise.
        * gas/riscv/cv-hwloop-counti.d: Likewise.
        * gas/riscv/cv-hwloop-endi.d: Likewise.
        * gas/riscv/cv-hwloop-setup.d: Likewise.
        * gas/riscv/cv-hwloop-setupi.d: Likewise.
        * gas/riscv/cv-hwloop-starti.d: Likewise.
        * gas/riscv/cv-hwloop-09.d: Likewise.
        * gas/riscv/cv-hwloop-10.d: Likewise.
        * gas/riscv/cv-march-rv32i-xcorev.s: Added test for march option.
        * gas/riscv/cv-march-rv32i-xcorev.d: Likewise.

include/ChangeLog.COREV:

	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
        instructions.
	* opcode/riscv.h: Added support for xcorevhwlp.

ld/testsuite/ChangeLog.COREV:

	* ld-riscv-elf/cv-hwloop-starti.d: Changed march option to xcorevhwlp.
        * ld-riscv-elf/cv-hwloop-endi.d: Likewise.
        * ld-riscv-elf/cv-hwloop-setup.d: Likewise.
        * ld-riscv-elf/cv-hwloop-setupi.d: Likewise.

opcodes/ChangeLog.COREV:

	* riscv-opc.c: Added support for corevhwlp.

Signed-off-by: Mary Bennett <mary.bennett@embecosm.com>